### PR TITLE
Implements support for :separated-by in rf-for

### DIFF
--- a/src/hopen/core.cljc
+++ b/src/hopen/core.cljc
@@ -19,9 +19,11 @@
             :else element))]
    (f-eval element)))
 
-;; Top level evaluation functions
-;; The given element can be a "block" to be executed or an simple expression to be evaluated
-(defn- rf-block [rf env result element]
+(defn- rf-block
+  "Top level evaluation functions
+  The given element can be a `block` to be executed or an simple expression to be evaluated."
+  [rf env result element]
+
   (or (when (list? element)
         (let [[f-symb & args] element
               f (get-in env [:block-macro f-symb])

--- a/test/hopen/core_test.cljc
+++ b/test/hopen/core_test.cljc
@@ -4,6 +4,21 @@
                                    :include-macros true])
             [hopen.core :refer [renderer default-env]]))
 
+(deftest parse-bindings-test
+  (testing "Spec the function's input and output"
+    (are [input output]
+      (= (parse-bindings input) output)
+
+      (seq [])
+      []
+
+      (seq '[var0 val0 :foo foo-val :bar bar-val
+             var1 val1
+             var2 val2 :separated-by "|"])
+      '[[var0 val0 {:foo foo-val :bar bar-val}]
+        [var1 val1 nil]
+        [var2 val2 {:separated-by "|"}]])))
+
 (deftest renderer-test
 
   (testing "basic testing"

--- a/test/hopen/core_test.cljc
+++ b/test/hopen/core_test.cljc
@@ -52,8 +52,8 @@
             [a b])]
         [:a 1 :a 2 :b 1 :b 2 :c 1 :c 2]
 
-        ['(for [a [:a :b :c] :join "|"
-                b (range 1 3) :join "-"]
+        ['(for [a [:a :b :c] :join ["|"]
+                b (range 1 3) :join ["-"]]
             [a b])]
         [:a 1 "-" :a 2 "|" :b 1 "-" :b 2 "|" :c 1 "-" :c 2]
 

--- a/test/hopen/core_test.cljc
+++ b/test/hopen/core_test.cljc
@@ -53,6 +53,11 @@
         [:a 1 :a 2 :b 1 :b 2 :c 1 :c 2]
 
         ['(for [a [:a :b :c] :join ["|"]
+                b (range 1 3)]
+            [a b])]
+        [:a 1 :a 2 "|" :b 1 :b 2 "|" :c 1 :c 2]
+
+        ['(for [a [:a :b :c] :join ["|"]
                 b (range 1 3) :join ["-"]]
             [a b])]
         [:a 1 "-" :a 2 "|" :b 1 "-" :b 2 "|" :c 1 "-" :c 2]

--- a/test/hopen/core_test.cljc
+++ b/test/hopen/core_test.cljc
@@ -47,9 +47,15 @@
         ['(inc (let [a 2 b 3] (+ a b)))] [6]
 
         ;; Block for
-        ['(for [a [:a :b :c] b (range 1 (+ 1 2))]
+        ['(for [a [:a :b :c]
+                b (range 1 3)]
             [a b])]
         [:a 1 :a 2 :b 1 :b 2 :c 1 :c 2]
+
+        ['(for [a [:a :b :c] :join "|"
+                b (range 1 3) :join "-"]
+            [a b])]
+        [:a 1 "-" :a 2 "|" :b 1 "-" :b 2 "|" :c 1 "-" :c 2]
 
         ;; Inline for
         ['(conj (for [a [:a :b :c] b (range 2)] [a b]) :x)]

--- a/test/hopen/core_test.cljc
+++ b/test/hopen/core_test.cljc
@@ -52,13 +52,13 @@
             [a b])]
         [:a 1 :a 2 :b 1 :b 2 :c 1 :c 2]
 
-        ['(for [a [:a :b :c] :join ["|"]
+        ['(for [a [:a :b :c] :separated-by ["|"]
                 b (range 1 3)]
             [a b])]
         [:a 1 :a 2 "|" :b 1 :b 2 "|" :c 1 :c 2]
 
-        ['(for [a [:a :b :c] :join ["|"]
-                b (range 1 3) :join ["-"]]
+        ['(for [a [:a :b :c] :separated-by ["|"]
+                b (range 1 3) :separated-by ["-"]]
             [a b])]
         [:a 1 "-" :a 2 "|" :b 1 "-" :b 2 "|" :c 1 "-" :c 2]
 

--- a/test/hopen/core_test.cljc
+++ b/test/hopen/core_test.cljc
@@ -2,7 +2,7 @@
   (:require #?(:clj  [clojure.test :refer [deftest testing is are]]
                :cljs [cljs.test    :refer [deftest testing is are]
                                    :include-macros true])
-            [hopen.core :refer [renderer default-env]]))
+            [hopen.core :refer [renderer default-env parse-bindings]]))
 
 (deftest parse-bindings-test
   (testing "Spec the function's input and output"
@@ -16,7 +16,7 @@
              var1 val1
              var2 val2 :separated-by "|"])
       '[[var0 val0 {:foo foo-val :bar bar-val}]
-        [var1 val1 nil]
+        [var1 val1 {}]
         [var2 val2 {:separated-by "|"}]])))
 
 (deftest renderer-test


### PR DESCRIPTION
Implements #1 

`rf-for` has been rewritten as a loop because we need some way to detect when we're processing the last item in some collection, in which case, we don't want to insert a separator.

The simple test cases seem to pass fine.

There is also an `inline-for`. Its not entirely clear to me why the contents `rf-for` is replicated there. In any case, `inline-for` does not yet support the :separated-by clause.